### PR TITLE
Lock constructor functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.0.0]
+
+### Added
+
+- `Maybe::nothing` to construct a `Nothing` instance
+- `Maybe::just` to construct a `Just` instance
+
+### Removed
+
+- `Just` and `Nothing` can no longer be constructed using `new`
+
+### Changed
+
+- `::of()` and `::empty()` have been marked `final` to prevent extension
+- `Just` and `Nothing` have been marked `final` to prevent extension
+
+## [1.0.0]
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ function prop($key)
 {
     return function ($xs)
     {
-        return new Maybe(
-            isset($xs[$key])
-                ? $xs[$key]
-                : null
+        return isset($xs[$key])
+            ? Maybe::of($xs[$key])
+            : Maybe::nothing();
         );
     };
 }
@@ -95,20 +94,13 @@ $value = Maybe::empty()
 assert($value == 'blah');
 ```
 
-### `__construct :: a -> Maybe a`
+### `just :: a -> Just a`
 
-Construct a new value, either Just or Nothing. `Just` requires one parameter, and Nothing requires no parameters (because the parameter would always be `null`):
+Standard constructor for `Just` instances. Typically you should call `Maybe::of` instead.
 
-```php
-<?php
+### `nothing :: a -> Nothing a`
 
-use PhpFp\Maybe\Maybe;
-
-assert(Maybe::of(12))->fork(5) == 12);
-assert(Maybe::empty())->fork(5) == 5);
-```
-
-The `fork` parameters are explained later on in this API description.
+Standard constructor for `Nothing` instances. Typically you should call `Maybe::nothing` instead.
 
 ### `ap :: Maybe (a -> b) | Maybe a -> Maybe b`
 

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
         {
             "name": "Tom",
             "email": "tomjharding@live.co.uk"
+        },
+        {
+            "name": "Woody Gilk",
+            "email": "woody.gilk@gmail.com",
+            "role": "Contributor"
         }
     ],
     "autoload": {

--- a/src/Constructor/Just.php
+++ b/src/Constructor/Just.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace PhpFp\Maybe\Constructor;
 
@@ -7,24 +8,8 @@ use PhpFp\Maybe\Maybe;
 /**
  * An OO-looking implementation of the Just constructor in PHP.
  */
-class Just extends Maybe
+final class Just extends Maybe
 {
-    /**
-     * The inner value for this Maybe.
-     * @var mixed
-     */
-    private $value = null;
-
-    /**
-     * Create a new Just instance.
-     * Don't construct this with a null!
-     * @param mixed $x The value to wrap.
-     */
-    public function __construct($value)
-    {
-        $this->value = $value;
-    }
-
     /**
      * Application, derived with chain.
      * @param Maybe $that The wrapped parameter.
@@ -116,5 +101,21 @@ class Just extends Maybe
     public function reduce(callable $f, $x)
     {
         return $f($x, $this->value);
+    }
+
+    /**
+     * The inner value for this Maybe.
+     * @var mixed
+     */
+    private $value = null;
+
+    /**
+     * Create a Maybe::just instance.
+     * Don't construct this with a null!
+     * @param mixed $x The value to wrap.
+     */
+    protected function __construct($value)
+    {
+        $this->value = $value;
     }
 }

--- a/src/Constructor/Nothing.php
+++ b/src/Constructor/Nothing.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace PhpFp\Maybe\Constructor;
 
@@ -7,7 +8,7 @@ use PhpFp\Maybe\Maybe;
 /**
  * An OO-looking implementation of the Nothing constructor in PHP.
  */
-class Nothing extends Maybe
+final class Nothing extends Maybe
 {
     /**
      * Application. Nothing acts as identity.

--- a/src/Maybe.php
+++ b/src/Maybe.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace PhpFp\Maybe;
 
@@ -10,22 +11,41 @@ use PhpFp\Maybe\Constructor\{Just, Nothing};
 abstract class Maybe
 {
     /**
-     * Empty value for the monoid definition.
-     * @return Maybe The Nothing value.
+     * Construct a new Just instance with a value.
+     * @param mixed $x The value to be wrapped.
+     * @return A new Just-constructed value.
      */
-    public static function empty() : Nothing
+    final public static function just($x) : Just
     {
-        return new Nothing;
+        return new Just($x);
+    }
+
+    /**
+     * Construct a new Nothing instance.
+     * @return A new Nothing-constructed value.
+     */
+    final public static function nothing() : Nothing
+    {
+        return new Nothing();
+    }
+
+    /**
+     * Empty value for the monoid definition.
+     * @return A new Nothing-constructed value.
+     */
+    final public static function empty() : Maybe
+    {
+        return self::nothing();
     }
 
     /**
      * Applicative constructor for Maybe.
      * @param mixed $x The value to be wrapped.
-     * @return A new Just-constructed type.
+     * @return A new Just-constructed value.
      */
-    public static function of($x) : Just
+    final public static function of($x) : Maybe
     {
-        return new Just($x);
+        return self::just($x);
     }
 
     /**

--- a/test/ConstructTest.php
+++ b/test/ConstructTest.php
@@ -22,13 +22,13 @@ class ConstructTest extends \PHPUnit_Framework_TestCase
     public function testConstruct()
     {
         $this->assertEquals(
-            (new Just(2))->fork(null),
+            (Maybe::just(2))->fork(null),
             2,
             'Constructs a Just.'
         );
 
         $this->assertEquals(
-            (new Nothing)->fork(-1),
+            Maybe::nothing()->fork(-1),
             -1,
             'Constructs a Nothing.'
         );


### PR DESCRIPTION
Removes the ability to construct new instances externally. All
construction must be done via `Maybe::just` or `Maybe::nothing` and this
functionality cannot be extended.

Also enforces `final` on all static methods, as their functionality
should never be changed by extension.

Refs php-fp/php-fp-either#7